### PR TITLE
Enable CORS in Luposdate Endpoint

### DIFF
--- a/endpoint/src/main/java/lupos/endpoint/server/Endpoint.java
+++ b/endpoint/src/main/java/lupos/endpoint/server/Endpoint.java
@@ -288,6 +288,7 @@ public class Endpoint {
 			} catch (final Error e) {
 				System.err.println(e);
 				e.printStackTrace();
+				t.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
 				t.getResponseHeaders().add("Content-type", "text/plain");
 				final String answer = "Error:\n"+e.getMessage();
 				System.out.println(answer);
@@ -296,6 +297,7 @@ public class Endpoint {
 			} catch (final Exception e){
 				System.err.println(e);
 				e.printStackTrace();
+				t.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
 				t.getResponseHeaders().add("Content-type", "text/plain");
 				final String answer = "Error:\n"+e.getMessage();
 				System.out.println(answer);


### PR DESCRIPTION
In order to be able to access the endpoint via XHR without using a proxy service, [CORS](http://enable-cors.org/server.html) has to be enabled. 

It might be preferable to make this a configurable option, though. 
