### PR TITLE
"equals(Object obj)" should test argument type

### DIFF
--- a/core/src/main/java/lupos/datastructures/dbmergesortedds/Entry.java
+++ b/core/src/main/java/lupos/datastructures/dbmergesortedds/Entry.java
@@ -72,6 +72,8 @@ public class Entry<E> implements Comparable<Entry<E>>, Serializable {
 	/** {@inheritDoc} */
 	@Override
 	public boolean equals(final Object other) {
+		if (this.getClass() != other.getClass())
+			return false;
 		return comp.compare(e, ((Entry<E>) other).e) == 0;
 	}
 

--- a/core/src/main/java/lupos/datastructures/dbmergesortedds/MapEntry.java
+++ b/core/src/main/java/lupos/datastructures/dbmergesortedds/MapEntry.java
@@ -77,6 +77,8 @@ public class MapEntry<K, V> implements Entry<K, V>, Serializable,
 	/** {@inheritDoc} */
 	@Override
 	public boolean equals(final Object other) {
+		if (this.getClass() != other.getClass())
+			return false;
 		return this.k.equals(((MapEntry<K, V>) other).k);
 	}
 

--- a/core/src/main/java/lupos/datastructures/simplifiedfractaltree/FractalTreeEntry.java
+++ b/core/src/main/java/lupos/datastructures/simplifiedfractaltree/FractalTreeEntry.java
@@ -120,6 +120,8 @@ public class FractalTreeEntry<K extends Comparable<K>, V> implements Comparable<
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean equals(final Object arg0) {
+		if (this.getClass() != arg0.getClass())
+			return false;
 		return this.compareTo((FractalTreeEntry<K, V>) arg0) == 0;
 	}
 

--- a/visualeditor/src/main/java/lupos/gui/operatorgraph/visualeditor/operators/RDFTerm.java
+++ b/visualeditor/src/main/java/lupos/gui/operatorgraph/visualeditor/operators/RDFTerm.java
@@ -160,6 +160,8 @@ public abstract class RDFTerm extends JTFOperator {
 
 	/** {@inheritDoc} */
 	public boolean equals(Object o) {
+		if (this.getClass() != o.getClass())
+			return false;
 		try {
 			return this.item == ((RDFTerm) o).item;
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2097 - “ "equals(Object obj)" should test argument type ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2097
Please let me know if you have any questions.
Ayman Abdelghany.