### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/core/src/main/java/lupos/datastructures/items/literal/LiteralFactory.java
+++ b/core/src/main/java/lupos/datastructures/items/literal/LiteralFactory.java
@@ -48,6 +48,9 @@ public class LiteralFactory {
 	 */
 	public static boolean semanticInterpretationOfLiterals = false;
 
+	private LiteralFactory() {
+	}
+
 	/**
 	 * <p>writeLuposLiteral.</p>
 	 *

--- a/core/src/main/java/lupos/datastructures/patriciatrie/node/NodeHelper.java
+++ b/core/src/main/java/lupos/datastructures/patriciatrie/node/NodeHelper.java
@@ -38,6 +38,9 @@ import lupos.misc.Triple;
 import lupos.misc.Tuple;
 public final class NodeHelper {
 
+	private NodeHelper() {
+	}
+
 	/**
 	 * Adds a key to the node.
 	 *

--- a/core/src/main/java/lupos/datastructures/sort/Sort.java
+++ b/core/src/main/java/lupos/datastructures/sort/Sort.java
@@ -42,6 +42,9 @@ import lupos.misc.IOCostsInputStream;
 import lupos.misc.IOCostsOutputStream;
 import lupos.misc.TimeInterval;
 public class Sort {
+	private Sort() {
+	}
+
 	public enum SORTER {
 		PARALLEL {
 

--- a/core/src/main/java/lupos/datastructures/sort/StringLengthStatistics.java
+++ b/core/src/main/java/lupos/datastructures/sort/StringLengthStatistics.java
@@ -40,6 +40,9 @@ public class StringLengthStatistics {
 	// scale used for divisions with BigDecimal numbers...
 	private final static int scale = 256;
 
+	private StringLengthStatistics() {
+	}
+
 	public static void main(final String[] args) throws Exception{
 		System.out.println("Determining string length statistics of a large collection of Strings or RDF terms of large RDF data...");
 		if(args.length<2){

--- a/core/src/main/java/lupos/datastructures/sort/helper/DataToBoundedBuffer.java
+++ b/core/src/main/java/lupos/datastructures/sort/helper/DataToBoundedBuffer.java
@@ -47,6 +47,9 @@ import lupos.misc.IOCostsInputStream;
  * @version $Id: $Id
  */
 public class DataToBoundedBuffer {
+	private DataToBoundedBuffer() {
+	}
+
 	/**
 	 * Read in and parse strings in a file (each line in the file is one string)
 	 * @param dataFiles the data

--- a/core/src/main/java/lupos/engine/indexconstruction/FastRDF3XIndexConstruction.java
+++ b/core/src/main/java/lupos/engine/indexconstruction/FastRDF3XIndexConstruction.java
@@ -107,6 +107,9 @@ public class FastRDF3XIndexConstruction {
 	/** Constant <code>map="new String[]{S, P, O}"</code> */
 	protected final static String[] map = new String[]{"S", "P", "O"};
 
+	private FastRDF3XIndexConstruction() {
+	}
+
 
 	/**
 	 * Constructs the large-scale indices for RDF3X.

--- a/core/src/main/java/lupos/engine/indexconstruction/FastRDF3XIntArrayIndexConstruction.java
+++ b/core/src/main/java/lupos/engine/indexconstruction/FastRDF3XIntArrayIndexConstruction.java
@@ -57,6 +57,9 @@ public class FastRDF3XIntArrayIndexConstruction {
 
 	private static final Logger log = LoggerFactory.getLogger(FastRDF3XIndexConstruction.class);
 
+	private FastRDF3XIntArrayIndexConstruction() {
+	}
+
 	public static void main(final String[] args) {
 
 		log.info("Starting program to construct an RDF3X Index for LUPOSDATE...");

--- a/core/src/main/java/lupos/engine/indexconstruction/RDF3XEmptyIndexConstruction.java
+++ b/core/src/main/java/lupos/engine/indexconstruction/RDF3XEmptyIndexConstruction.java
@@ -63,6 +63,9 @@ public class RDF3XEmptyIndexConstruction {
 	private static final int k = 1000;
 	private static final int k_ = 1000;
 
+	private RDF3XEmptyIndexConstruction() {
+	}
+
 	/**
 	 * Entry point to create an empty RDF3X disk-based index
 	 *

--- a/core/src/main/java/lupos/engine/indexconstruction/RDF3XIndexConstruction.java
+++ b/core/src/main/java/lupos/engine/indexconstruction/RDF3XIndexConstruction.java
@@ -85,6 +85,9 @@ public class RDF3XIndexConstruction {
 	/** Constant <code>LIMIT_ELEMENTS_IN_TRIE=50000000</code> */
 	public static long LIMIT_ELEMENTS_IN_TRIE = 50000000;
 
+	private RDF3XIndexConstruction() {
+	}
+
 	/**
 	 * <p>insertUsedStringRepresentations.</p>
 	 *

--- a/core/src/main/java/lupos/engine/indexconstruction/RDF3XStringArrayIndexConstruction.java
+++ b/core/src/main/java/lupos/engine/indexconstruction/RDF3XStringArrayIndexConstruction.java
@@ -62,6 +62,9 @@ public class RDF3XStringArrayIndexConstruction {
 
 	private static final Logger log = LoggerFactory.getLogger(RDF3XStringArrayIndexConstruction.class);
 
+	private RDF3XStringArrayIndexConstruction() {
+	}
+
 	public static void main(final String[] args) {
 		log.info("Starting program to construct an RDF3X String Index for LUPOSDATE...");
 		log.debug("[help is printed when using less than 5 command line arguments]");

--- a/core/src/main/java/lupos/engine/operators/singleinput/filter/expressionevaluation/Helper.java
+++ b/core/src/main/java/lupos/engine/operators/singleinput/filter/expressionevaluation/Helper.java
@@ -44,6 +44,9 @@ import org.apache.xerces.impl.xpath.regex.Match;
 import org.apache.xerces.impl.xpath.regex.RegularExpression;
 public class Helper {
 
+	private Helper() {
+	}
+
 	/**
 	 * <p>booleanEffectiveValue.</p>
 	 *

--- a/core/src/main/java/lupos/engine/operators/singleinput/generate/GenerateBlankNodes.java
+++ b/core/src/main/java/lupos/engine/operators/singleinput/generate/GenerateBlankNodes.java
@@ -32,6 +32,9 @@ public class GenerateBlankNodes {
 
 	private static int idBlankNodes = 0;
 
+	private GenerateBlankNodes() {
+	}
+
 	/**
 	 * <p>getBlankNode.</p>
 	 *

--- a/core/src/main/java/lupos/io/Registration.java
+++ b/core/src/main/java/lupos/io/Registration.java
@@ -60,6 +60,9 @@ import lupos.misc.Tuple;
 @SuppressWarnings("rawtypes")
 public class Registration {
 
+	private Registration() {
+	}
+
 	public interface DeSerializer<T> {
 
 		public int length(T t);

--- a/core/src/main/java/lupos/io/helper/InputHelper.java
+++ b/core/src/main/java/lupos/io/helper/InputHelper.java
@@ -62,6 +62,9 @@ import lupos.io.Registration;
 import lupos.optimizations.logical.statistics.VarBucket;
 public final class InputHelper {
 
+	private InputHelper() {
+	}
+
 	/**
 	 * <p>readLuposString.</p>
 	 *

--- a/core/src/main/java/lupos/io/helper/LengthHelper.java
+++ b/core/src/main/java/lupos/io/helper/LengthHelper.java
@@ -51,6 +51,9 @@ import lupos.io.LuposObjectInputStream;
 import lupos.io.Registration;
 import lupos.optimizations.logical.statistics.VarBucket;
 public final class LengthHelper {
+	private LengthHelper() {
+	}
+
 	/**
 	 * <p>lengthLuposTriple.</p>
 	 *

--- a/core/src/main/java/lupos/io/helper/OutHelper.java
+++ b/core/src/main/java/lupos/io/helper/OutHelper.java
@@ -56,6 +56,9 @@ import lupos.io.Registration;
 import lupos.optimizations.logical.statistics.VarBucket;
 public final class OutHelper {
 
+	private OutHelper() {
+	}
+
 	/**
 	 * <p>writeLuposTriple.</p>
 	 *

--- a/core/src/main/java/lupos/misc/ByteHelper.java
+++ b/core/src/main/java/lupos/misc/ByteHelper.java
@@ -31,6 +31,9 @@ package lupos.misc;
  */
 public class ByteHelper {
 
+	private ByteHelper() {
+	}
+
 	/**
 	 * Converts a given integer value to a byte array
 	 *

--- a/core/src/main/java/lupos/misc/FileHelper.java
+++ b/core/src/main/java/lupos/misc/FileHelper.java
@@ -35,6 +35,9 @@ public class FileHelper {
 
 	private static final Logger log = LoggerFactory.getLogger(FileHelper.class);
 
+	private FileHelper() {
+	}
+
 	/**
 	 * <p>deleteDirectory.</p>
 	 *

--- a/core/src/main/java/lupos/optimizations/logical/rules/findsubgraph/FindSubGraph.java
+++ b/core/src/main/java/lupos/optimizations/logical/rules/findsubgraph/FindSubGraph.java
@@ -37,6 +37,9 @@ import lupos.engine.operators.multiinput.optional.Optional;
 import lupos.engine.operators.singleinput.Projection;
 public class FindSubGraph {
 
+	private FindSubGraph() {
+	}
+
 	/**
 	 * This method checks if a given graph S is a subgraph of another graph T
 	 * starting at given nodes. Only the operatortype is checked and the

--- a/core/src/main/java/lupos/optimizations/logical/statistics/Statistics.java
+++ b/core/src/main/java/lupos/optimizations/logical/statistics/Statistics.java
@@ -29,6 +29,9 @@ import java.util.Map;
 import lupos.datastructures.items.Variable;
 public class Statistics {
 
+	private Statistics() {
+	}
+
 	/**
 	 * <p>estimateJoinSelectivity.</p>
 	 *

--- a/core/src/main/java/lupos/optimizations/physical/PhysicalOptimizations.java
+++ b/core/src/main/java/lupos/optimizations/physical/PhysicalOptimizations.java
@@ -67,6 +67,9 @@ public class PhysicalOptimizations {
 	private static HashMap<Class<? extends BasicOperator>, Class<? extends BasicOperator>> replacements = new HashMap<Class<? extends BasicOperator>, Class<? extends BasicOperator>>();
 	private static HashMap<Class<? extends BasicOperator>, Class<? extends BasicOperator>> replacementsMergeJoinAndMergeOptional = new HashMap<Class<? extends BasicOperator>, Class<? extends BasicOperator>>();
 
+	private PhysicalOptimizations() {
+	}
+
 	/**
 	 * Adds a rule that replaces a superclass with its implementation (Both
 	 * classes have to inherit from Operator)

--- a/distributed/src/main/java/lupos/distributed/operator/format/Helper.java
+++ b/distributed/src/main/java/lupos/distributed/operator/format/Helper.java
@@ -42,6 +42,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 public class Helper {
 
+	private Helper() {
+	}
+
 	/**
 	 * Creates a json object from a given object
 	 *

--- a/distributed/src/main/java/lupos/distributed/storage/util/LocalExecutor.java
+++ b/distributed/src/main/java/lupos/distributed/storage/util/LocalExecutor.java
@@ -82,6 +82,9 @@ import org.json.JSONObject;
  */
 public class LocalExecutor {
 
+	private LocalExecutor() {
+	}
+
 	/**
 	 * This methods transforms a subgraph given as serialized JSON string into an operator graph,
 	 * which is executed and its result is returned serialized as string in JSON format...

--- a/distributedendpoints/src/main/java/lupos/distributedendpoints/endpoint/ClearIndex.java
+++ b/distributedendpoints/src/main/java/lupos/distributedendpoints/endpoint/ClearIndex.java
@@ -36,6 +36,9 @@ import lupos.engine.indexconstruction.RDF3XEmptyIndexConstruction;
  */
 public class ClearIndex {
 
+	private ClearIndex() {
+	}
+
 	/**
 	 * main entry point of the program
 	 *

--- a/distributedendpoints/src/main/java/lupos/distributedendpoints/endpoint/StartEndpoint.java
+++ b/distributedendpoints/src/main/java/lupos/distributedendpoints/endpoint/StartEndpoint.java
@@ -60,6 +60,9 @@ import com.sun.net.httpserver.HttpExchange;
  */
 public class StartEndpoint {
 
+	private StartEndpoint() {
+	}
+
 	/**
 	 * Main entry point to start the endpoints...
 	 *

--- a/distributedendpoints/src/main/java/lupos/distributedendpoints/gui/Start_Demo_Applet_DE.java
+++ b/distributedendpoints/src/main/java/lupos/distributedendpoints/gui/Start_Demo_Applet_DE.java
@@ -42,6 +42,9 @@ import lupos.gui.Demo_Applet;
  */
 public class Start_Demo_Applet_DE {
 
+	private Start_Demo_Applet_DE() {
+	}
+
 	/**
 	 * <p>main.</p>
 	 *

--- a/distributedendpoints/src/main/java/lupos/distributedendpoints/storage/util/QueryBuilder.java
+++ b/distributedendpoints/src/main/java/lupos/distributedendpoints/storage/util/QueryBuilder.java
@@ -38,6 +38,9 @@ import lupos.engine.operators.tripleoperator.TriplePattern;
  */
 public class QueryBuilder {
 
+	private QueryBuilder() {
+	}
+
 	/**
 	 * Builds an insert-data-query, which inserts all given triples
 	 *

--- a/distributedp2p/src/main/java/lupos/distributed/p2p/commandline/VisualizationHelper.java
+++ b/distributedp2p/src/main/java/lupos/distributed/p2p/commandline/VisualizationHelper.java
@@ -42,6 +42,9 @@ import lupos.gui.operatorgraph.viewer.Viewer;
 import xpref.XPref;
 public class VisualizationHelper {
 
+	private VisualizationHelper() {
+	}
+
 	/**
 	 * Displays the operatorgraph in an UI window
 	 *

--- a/distributedp2p/src/main/java/lupos/distributed/p2p/gui/Start_Demo_Applet_DE.java
+++ b/distributedp2p/src/main/java/lupos/distributed/p2p/gui/Start_Demo_Applet_DE.java
@@ -34,6 +34,9 @@ import lupos.gui.Demo_Applet;
  */
 public class Start_Demo_Applet_DE {
 
+	private Start_Demo_Applet_DE() {
+	}
+
 	/**
 	 * <p>main.</p>
 	 *

--- a/distributedp2p/src/main/java/lupos/distributed/p2p/network/P2PNetworkCreator.java
+++ b/distributedp2p/src/main/java/lupos/distributed/p2p/network/P2PNetworkCreator.java
@@ -98,6 +98,9 @@ public class P2PNetworkCreator {
 		 * implementation)
 		 */
 		public static final String cSTORAGE_PATH = "StoragePath";
+
+		private P2PConfigurationConstants() {
+		}
 	}
 
 	/**

--- a/distributedp2p/src/main/java/lupos/distributed/p2p/network/impl/EndpointNetwork.java
+++ b/distributedp2p/src/main/java/lupos/distributed/p2p/network/impl/EndpointNetwork.java
@@ -184,6 +184,9 @@ public class EndpointNetwork extends P2PTripleNetwork {
 	 */
 	public static class DataFileDistribution {
 
+		private DataFileDistribution() {
+		}
+
 		private static String getKey(final KeyContainer<?> keyContainer) {
 			return String.format("%s%s", keyContainer.type, keyContainer.key);
 		}

--- a/distributedp2p/src/main/java/lupos/distributed/p2p/query/withsubgraph/P2P_SubgraphExecuter.java
+++ b/distributedp2p/src/main/java/lupos/distributed/p2p/query/withsubgraph/P2P_SubgraphExecuter.java
@@ -109,6 +109,9 @@ public class P2P_SubgraphExecuter<T> implements
 	public static class P2PInputStreamMessage {
 		public static final int HEADING_BYTES = 37;
 
+		private P2PInputStreamMessage() {
+		}
+
 		/**
 		 * Creates a header for the input stream that is added first
 		 *

--- a/endpoint/src/main/java/lupos/endpoint/caching/DeltaClient.java
+++ b/endpoint/src/main/java/lupos/endpoint/caching/DeltaClient.java
@@ -96,6 +96,9 @@ public class DeltaClient {
 		}
 	}
 
+	private DeltaClient() {
+	}
+
 	/**
 	 * This main method calls the main method of CommandLineEvaluator (after the DeltaClient has been initialized).
 	 * The delta approach for caching and reusing query triples is used for any communication with an endpoint

--- a/endpoint/src/main/java/lupos/endpoint/caching/DeltaEndpoint.java
+++ b/endpoint/src/main/java/lupos/endpoint/caching/DeltaEndpoint.java
@@ -60,6 +60,9 @@ import com.sun.net.httpserver.HttpExchange;
  */
 public class DeltaEndpoint {
 
+	private DeltaEndpoint() {
+	}
+
 	/**
 	 * <p>main.</p>
 	 *

--- a/endpoint/src/main/java/lupos/endpoint/client/Client.java
+++ b/endpoint/src/main/java/lupos/endpoint/client/Client.java
@@ -89,6 +89,10 @@ public class Client {
 		Client.registerFormatReader(new TripleFormatReader("Turtle", "text/turtle", "Turtle"));
 		Client.registerFormatReader(new TripleFormatReader("RDF XML", "application/rdf+xml", "Rdfxml"));
 	}
+
+	private Client() {
+	}
+
 	public static void registerFormatReader(final MIMEFormatReader formatReader){
 		Client.registeredFormatReaders.put(formatReader.getMIMEType(), formatReader);
 	}

--- a/endpoint/src/main/java/lupos/endpoint/client/CommandLineEvaluator.java
+++ b/endpoint/src/main/java/lupos/endpoint/client/CommandLineEvaluator.java
@@ -31,6 +31,9 @@ import lupos.engine.operators.singleinput.federated.FederatedQueryBitVectorJoinN
 import lupos.sparql1_1.operatorgraph.ServiceApproaches;
 public class CommandLineEvaluator {
 
+	private CommandLineEvaluator() {
+	}
+
 	/**
 	 * <p>main.</p>
 	 *

--- a/endpoint/src/main/java/lupos/endpoint/server/Endpoint.java
+++ b/endpoint/src/main/java/lupos/endpoint/server/Endpoint.java
@@ -97,6 +97,9 @@ public class Endpoint {
 	private static final int delayForStoppingInSeconds = 30; // the time the server gets for stopping to finish its work
 	public static final int portForStopping = 4242; // the port on which the server listens for stop signal
 
+	private Endpoint() {
+	}
+
 	public static enum EVALUATOR {
 		RDF3X {
 			@Override

--- a/endpoint/src/main/java/lupos/endpoint/server/StopServer.java
+++ b/endpoint/src/main/java/lupos/endpoint/server/StopServer.java
@@ -34,7 +34,10 @@ import java.net.UnknownHostException;
  */
 public class StopServer {
 
-	public static void main(final String[] args) throws UnknownHostException, IOException {
+    private StopServer() {
+    }
+
+    public static void main(final String[] args) throws UnknownHostException, IOException {
 		System.out.println("Stopping the LUPOSDATE Endpoint...");
 		// Start Socket listener for receiving signal for stopping the server...
 		final Socket socket = new Socket("localhost", Endpoint.portForStopping);

--- a/endpoint/src/main/java/lupos/engine/evaluators/SaveRDF3XResult.java
+++ b/endpoint/src/main/java/lupos/engine/evaluators/SaveRDF3XResult.java
@@ -33,6 +33,9 @@ import lupos.endpoint.server.format.XMLFormatter;
 import lupos.misc.FileHelper;
 import lupos.sparql1_1.operatorgraph.ServiceApproaches;
 public class SaveRDF3XResult {
+	private SaveRDF3XResult() {
+	}
+
 	/**
 	 * <p>main.</p>
 	 *

--- a/extendedendpoint/src/main/java/lupos/endpoint/EvaluationHelper.java
+++ b/extendedendpoint/src/main/java/lupos/endpoint/EvaluationHelper.java
@@ -91,6 +91,9 @@ public class EvaluationHelper {
 	 */
 	protected final static RuleSets rulesets = new RuleSets("/rif/");
 
+	private EvaluationHelper() {
+	}
+
 	/**
 	 * for initialization purposes...
 	 * to be called only once...

--- a/extendedendpoint/src/main/java/lupos/endpoint/ExtendedEndpoint.java
+++ b/extendedendpoint/src/main/java/lupos/endpoint/ExtendedEndpoint.java
@@ -43,6 +43,9 @@ public class ExtendedEndpoint {
 	private final static String INDEX_DIR = "luposdate-index";
 	private final static String INDEX_FILE = "src/main/resources/sp2b.n3";
 
+	private ExtendedEndpoint() {
+	}
+
 	public static void main(final String[] args) throws Exception {
 
 		// init the SPARQL evaluators, the luposdate endpoint could be extended

--- a/extendedendpoint/src/main/java/lupos/endpoint/GraphSerialization.java
+++ b/extendedendpoint/src/main/java/lupos/endpoint/GraphSerialization.java
@@ -38,6 +38,9 @@ import lupos.gui.operatorgraph.graphwrapper.GraphWrapperRules;
 import org.json.JSONObject;
 
 public class GraphSerialization {
+	private GraphSerialization() {
+	}
+
 	public enum AstFormat {
 		GRAPH, NESTED
 	}

--- a/extendedendpoint/src/main/java/lupos/endpoint/contexts/QueryHandlerHelper.java
+++ b/extendedendpoint/src/main/java/lupos/endpoint/contexts/QueryHandlerHelper.java
@@ -39,6 +39,9 @@ public class QueryHandlerHelper {
 	public static final int HTTP_METHOD_NOT_ALLOWED = 405;
 	public static final int HTTP_INTERNAL_SERVER_ERROR = 500;
 
+	private QueryHandlerHelper() {
+	}
+
 	public static void setDefaultHeaders(final HttpExchange t) {
 		t.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
 		t.getResponseHeaders().add("Content-Type", "application/json");

--- a/geosparql/src/main/java/lupos/endpoint/server/Geo_Endpoint.java
+++ b/geosparql/src/main/java/lupos/endpoint/server/Geo_Endpoint.java
@@ -27,6 +27,9 @@ import lupos.geo.geosparql.GeoFunctionRegisterer;
 import lupos.geo.stsparql.functions.StFunctionRegisterer;
 public class Geo_Endpoint {
 
+	private Geo_Endpoint() {
+	}
+
 	/**
 	 * <p>main.</p>
 	 *

--- a/geosparql/src/main/java/lupos/geo/GeoFactory.java
+++ b/geosparql/src/main/java/lupos/geo/GeoFactory.java
@@ -34,6 +34,9 @@ import com.vividsolutions.jts.geom.GeometryFactory;
  */
 public class GeoFactory
 {
+    private GeoFactory() {
+    }
+
     /**
      * The default JTS factory for creating geometries.
      *

--- a/geosparql/src/main/java/lupos/geo/GeoHelper.java
+++ b/geosparql/src/main/java/lupos/geo/GeoHelper.java
@@ -59,6 +59,9 @@ public class GeoHelper
     /** Constant <code>stSPARQLFunctionUri="stURI"</code> */
     public static final String stSPARQLFunctionUri = stURI;
 
+    private GeoHelper() {
+    }
+
     /**
      * <p>getGeoSPARQLGeometry.</p>
      *

--- a/geosparql/src/main/java/lupos/geo/geosparql/GeoFunctionRegisterer.java
+++ b/geosparql/src/main/java/lupos/geo/geosparql/GeoFunctionRegisterer.java
@@ -61,6 +61,9 @@ import lupos.geo.geosparql.functions.sf_eh.GeofSfTouchesEhMeet;
  */
 public class GeoFunctionRegisterer {
 
+    private GeoFunctionRegisterer() {
+    }
+
     /**
      * <p>registerGeoFunctions.</p>
      */

--- a/geosparql/src/main/java/lupos/geo/geosparql/UnitOfMeasurement.java
+++ b/geosparql/src/main/java/lupos/geo/geosparql/UnitOfMeasurement.java
@@ -42,6 +42,9 @@ public class UnitOfMeasurement {
         conversionRate.put("<http://www.opengis.net/def/uom/OGC/1.0/metre>", 1.0);
     }
 
+    private UnitOfMeasurement() {
+    }
+
     /**
      * <p>convert.</p>
      *

--- a/geosparql/src/main/java/lupos/geo/stsparql/functions/StFunctionRegisterer.java
+++ b/geosparql/src/main/java/lupos/geo/stsparql/functions/StFunctionRegisterer.java
@@ -41,6 +41,9 @@ import lupos.geo.stsparql.functions.relations.Touches;
 import lupos.geo.stsparql.functions.relations.Within;
 public class StFunctionRegisterer {
 
+	private StFunctionRegisterer() {
+	}
+
 	/**
 	 * <p>registerStFunctions.</p>
 	 */

--- a/geosparql/src/main/java/lupos/gui/Geo_Demo_Applet.java
+++ b/geosparql/src/main/java/lupos/gui/Geo_Demo_Applet.java
@@ -34,6 +34,9 @@ import lupos.geo.stsparql.functions.StFunctionRegisterer;
  */
 public class Geo_Demo_Applet {
 
+	private Geo_Demo_Applet() {
+	}
+
 	/**
 	 * <p>main.</p>
 	 *

--- a/geosparql/src/main/java/lupos/gui/Geo_RDF3X_Client.java
+++ b/geosparql/src/main/java/lupos/gui/Geo_RDF3X_Client.java
@@ -27,6 +27,9 @@ import lupos.geo.geosparql.GeoFunctionRegisterer;
 import lupos.geo.stsparql.functions.StFunctionRegisterer;
 public class Geo_RDF3X_Client {
 
+	private Geo_RDF3X_Client() {
+	}
+
 	/**
 	 * <p>main.</p>
 	 *

--- a/gui/src/main/java/lupos/distributed/gui/Start_Demo_Applet.java
+++ b/gui/src/main/java/lupos/distributed/gui/Start_Demo_Applet.java
@@ -35,6 +35,9 @@ import lupos.sparql1_1.Node;
  */
 public class Start_Demo_Applet {
 
+	private Start_Demo_Applet() {
+	}
+
 	/**
 	 * This method starts the Demo_Applet. It is assumed that the first command line argument contains
 	 * the class name of the distributed query evaluator.

--- a/gui/src/main/java/lupos/endpoint/server/DebugEndpoint.java
+++ b/gui/src/main/java/lupos/endpoint/server/DebugEndpoint.java
@@ -66,6 +66,9 @@ public class DebugEndpoint {
 	/** Constant <code>logDirectory="c:/luposdate/log/"</code> */
 	public static String logDirectory = "c:/luposdate/log/";
 
+	private DebugEndpoint() {
+	}
+
 	/**
 	 * <p>main.</p>
 	 *

--- a/gui/src/main/java/lupos/engine/evaluators/EvaluatorCreator.java
+++ b/gui/src/main/java/lupos/engine/evaluators/EvaluatorCreator.java
@@ -61,6 +61,9 @@ import xpref.datatypes.IntegerDatatype;
 import xpref.datatypes.StringDatatype;
 public final class EvaluatorCreator {
 
+	private EvaluatorCreator() {
+	}
+
 	public enum EVALUATORS{
 		RDF3X {
 			@Override

--- a/gui/src/main/java/lupos/gui/InferenceHelper.java
+++ b/gui/src/main/java/lupos/gui/InferenceHelper.java
@@ -29,6 +29,9 @@ public class InferenceHelper {
 	/** Constant <code>genSet</code> */
 	protected static InferenceRulesGeneratorSetup genSet;
 
+	private InferenceHelper() {
+	}
+
 	/**
 	 * <p>getRIFInferenceRulesForRDFSOntology.</p>
 	 *

--- a/integrationJena/src/main/java/lupos/rdf/parser/RdfxmlParser.java
+++ b/integrationJena/src/main/java/lupos/rdf/parser/RdfxmlParser.java
@@ -28,6 +28,9 @@ import java.io.UnsupportedEncodingException;
 
 import lupos.engine.operators.tripleoperator.TripleConsumer;
 public class RdfxmlParser {
+	private RdfxmlParser() {
+	}
+
 	/**
 	 * <p>parseRDFData.</p>
 	 *

--- a/integrationJena/src/main/java/lupos/rdf/parser/TurtleParser.java
+++ b/integrationJena/src/main/java/lupos/rdf/parser/TurtleParser.java
@@ -41,8 +41,11 @@ import lupos.datastructures.items.literal.TypedLiteralOriginalContent;
 import lupos.engine.operators.tripleoperator.TripleConsumer;
 public class TurtleParser {
 	/** Constant <code>readFileNumber=0</code> */
-	public static int readFileNumber=0; 
-	
+	public static int readFileNumber=0;
+
+	private TurtleParser() {
+	}
+
 	/**
 	 * <p>parseRDFData.</p>
 	 *

--- a/integrationNxParser/src/main/java/lupos/rdf/parser/NquadsParser.java
+++ b/integrationNxParser/src/main/java/lupos/rdf/parser/NquadsParser.java
@@ -35,7 +35,9 @@ import lupos.datastructures.items.literal.Literal;
 import lupos.datastructures.items.literal.LiteralFactory;
 import lupos.engine.operators.tripleoperator.TripleConsumer;
 public class NquadsParser {
-	
+	private NquadsParser() {
+	}
+
 	// Using the parser NxParser for NQUADS
 	/**
 	 * <p>parseRDFData.</p>

--- a/integrationSesame/src/main/java/lupos/rdf/parser/SesamentriplesParser.java
+++ b/integrationSesame/src/main/java/lupos/rdf/parser/SesamentriplesParser.java
@@ -29,6 +29,9 @@ import java.io.UnsupportedEncodingException;
 import lupos.engine.operators.tripleoperator.TripleConsumer;
 import lupos.rdf.parser.SesameturtleParser.SesameParserType;
 public class SesamentriplesParser {
+	private SesamentriplesParser() {
+	}
+
 	/**
 	 * <p>parseRDFData.</p>
 	 *

--- a/integrationSesame/src/main/java/lupos/rdf/parser/SesamerdfxmlParser.java
+++ b/integrationSesame/src/main/java/lupos/rdf/parser/SesamerdfxmlParser.java
@@ -29,6 +29,9 @@ import java.io.UnsupportedEncodingException;
 import lupos.engine.operators.tripleoperator.TripleConsumer;
 import lupos.rdf.parser.SesameturtleParser.SesameParserType;
 public class SesamerdfxmlParser {
+	private SesamerdfxmlParser() {
+	}
+
 	/**
 	 * <p>parseRDFData.</p>
 	 *

--- a/integrationSesame/src/main/java/lupos/rdf/parser/SesameturtleParser.java
+++ b/integrationSesame/src/main/java/lupos/rdf/parser/SesameturtleParser.java
@@ -47,7 +47,10 @@ import org.openrdf.rio.ntriples.NTriplesParser;
 import org.openrdf.rio.rdfxml.RDFXMLParser;
 import org.openrdf.rio.turtle.TurtleParser;
 public class SesameturtleParser {
-	
+
+	private SesameturtleParser() {
+	}
+
 	/**
 	 * <p>parseRDFData.</p>
 	 *

--- a/internetofevents/src/main/java/lupos/event/consumer/app/charts/ChartFactory.java
+++ b/internetofevents/src/main/java/lupos/event/consumer/app/charts/ChartFactory.java
@@ -33,6 +33,9 @@ import lupos.datastructures.queryresult.QueryResult;
  */
 public class ChartFactory {
 
+	private ChartFactory() {
+	}
+
 	/**
 	 * Finds and returns the ChartHandler GUI for the given type of chart
 	 *

--- a/internetofevents/src/main/java/lupos/event/consumer/html/Encode.java
+++ b/internetofevents/src/main/java/lupos/event/consumer/html/Encode.java
@@ -60,6 +60,9 @@ public class Encode {
  	/** Constant <code>IMAGE="START + IMAGE + END"</code> */
  	public final static String IMAGE = START + "IMAGE" + END;
 
+	private Encode() {
+	}
+
 	/**
 	 * Creates the String for the Content function.
 	 *

--- a/internetofevents/src/main/java/lupos/event/consumer/html/Main.java
+++ b/internetofevents/src/main/java/lupos/event/consumer/html/Main.java
@@ -35,6 +35,9 @@ import lupos.event.consumer.Consumer;
  */
 public class Main {
 
+	private Main() {
+	}
+
 	@SuppressWarnings("unused")
 	 /**
 	  * Initializing main class

--- a/internetofevents/src/main/java/lupos/event/consumer/html/Utils.java
+++ b/internetofevents/src/main/java/lupos/event/consumer/html/Utils.java
@@ -40,7 +40,10 @@ import java.util.Scanner;
  * @version $Id: $Id
  */
 public class Utils {
-	
+
+	private Utils() {
+	}
+
 	/**
 	 * Writes a files with a certain path with content.
 	 *

--- a/internetofevents/src/main/java/lupos/event/producer/MoonProducer.java
+++ b/internetofevents/src/main/java/lupos/event/producer/MoonProducer.java
@@ -82,6 +82,9 @@ public class MoonProducer extends ProducerBaseNoDuplicates {
 		public static final URILiteral SUNSET_HOUR = Literals.createURI(NAMESPACE, "sunset_hour");
 		/** minute of the sunset */
 		public static final URILiteral SUNSET_MINUTE = Literals.createURI(NAMESPACE, "sunset_minute");
+
+		private Predicates() {
+		}
 	}
 	
 	

--- a/internetofevents/src/main/java/lupos/event/producer/MtGoxProducer.java
+++ b/internetofevents/src/main/java/lupos/event/producer/MtGoxProducer.java
@@ -72,6 +72,9 @@ public class MtGoxProducer extends ProducerBaseNoDuplicates {
 		public static final Literal LAST_TRADE = Literals.createURI(NAMESPACE, "lastTrade");
 		public static final Literal BEST_BID = Literals.createURI(NAMESPACE, "bestBid");
 		public static final Literal BEST_ASK = Literals.createURI(NAMESPACE, "bestAsk");
+
+		private Predicates() {
+		}
 	}
 	
 	/**

--- a/internetofevents/src/main/java/lupos/event/producer/SysMonProducer.java
+++ b/internetofevents/src/main/java/lupos/event/producer/SysMonProducer.java
@@ -65,6 +65,9 @@ public class SysMonProducer extends ProducerBaseNoDuplicates {
 		public static final URILiteral FREE_PHYSICAL_BYTES = Literals.createURI(NAMESPACE, "freePhysicalBytes");
 		public static final URILiteral TOTAL_SWAP_BYTES = Literals.createURI(NAMESPACE, "totalSwapBytes");
 		public static final URILiteral FREE_SWAP_BYTES = Literals.createURI(NAMESPACE, "freeSwapBytes");
+
+		private Predicates() {
+		}
 	}
 
 

--- a/internetofevents/src/main/java/lupos/event/producer/WeatherProducer.java
+++ b/internetofevents/src/main/java/lupos/event/producer/WeatherProducer.java
@@ -147,6 +147,9 @@ public class WeatherProducer extends ProducerBaseNoDuplicates {
 		public static final URILiteral LONGITUDE2 = Literals.createURI(NAMESPACE, "longi2");
 		/** elevation of the asked city */
 		public static final URILiteral ELEVATION2 = Literals.createURI(NAMESPACE, "elev2");
+
+		private Predicates() {
+		}
 	}
 
 	

--- a/internetofevents/src/main/java/lupos/event/producer/ebay/EbayProducer.java
+++ b/internetofevents/src/main/java/lupos/event/producer/ebay/EbayProducer.java
@@ -52,6 +52,9 @@ public class EbayProducer extends ProducerBaseNoDuplicates {
 		public static final Literal CURRENTPRICE = Literals.createURI(NAMESPACE, "currentPrice");
 		public static final Literal BUYITNOWPRICE = Literals.createURI(NAMESPACE, "buyItNowPrice");
 		public static final Literal SHIPPINGCOSTS = Literals.createURI(NAMESPACE, "shippingCosts");
+
+		private Predicates() {
+		}
 	}
 	
 	private int subjectCounter = 0;

--- a/internetofevents/src/main/java/lupos/event/producer/rsssemantics/DBAnswer.java
+++ b/internetofevents/src/main/java/lupos/event/producer/rsssemantics/DBAnswer.java
@@ -75,6 +75,9 @@ public class DBAnswer {
 				DBAnswer.NAMESPACE, "Comment");
 		public static final URILiteral BIRTHPLACE = Literals.createURI(
 				DBAnswer.NAMESPACE, "BirthPlace");
+
+		private Predicates() {
+		}
 	}
 
 	/**

--- a/internetofevents/src/main/java/lupos/event/producer/rsssemantics/FeedMessage.java
+++ b/internetofevents/src/main/java/lupos/event/producer/rsssemantics/FeedMessage.java
@@ -49,6 +49,9 @@ public class FeedMessage {
 	  public static final URILiteral LINK = Literals.createURI(FeedMessage.NAMESPACE, "Link");
 	  public static final URILiteral AUTHOR = Literals.createURI(FeedMessage.NAMESPACE, "Author");
 	  public static final URILiteral GUID = Literals.createURI(FeedMessage.NAMESPACE, "guid");
+
+	  private Predicates() {
+	  }
   }
   
   /**

--- a/internetofevents/src/main/java/lupos/event/producer/rsssemantics/RSSSemanticInterpretationProducer.java
+++ b/internetofevents/src/main/java/lupos/event/producer/rsssemantics/RSSSemanticInterpretationProducer.java
@@ -54,6 +54,9 @@ public class RSSSemanticInterpretationProducer extends ProducerBaseNoDuplicates 
 				"FeedToInterpret");
 		public static final Literal INTERPRETATION = Literals.createURI(
 				NAMESPACE, "DBPediaResult");
+
+		private Predicates() {
+		}
 	}
 
 	/**

--- a/internetofevents/src/main/java/lupos/event/util/Literals.java
+++ b/internetofevents/src/main/java/lupos/event/util/Literals.java
@@ -42,6 +42,9 @@ public abstract class Literals {
 	 */
 	public static class RDF {
 		public static final Literal TYPE = createURI(Prefixes.RDF, "type");
+
+		private RDF() {
+		}
 	}
 
 	/**
@@ -58,6 +61,9 @@ public abstract class Literals {
 		public static final URILiteral TIME = createURI(Prefixes.XSD, "time");
 		public static final URILiteral DATETIME = createURI(Prefixes.XSD, "dateTime");
 		public static final URILiteral ANYURI = createURI(Prefixes.XSD, "anyURI");
+
+		private XSD() {
+		}
 	}
 
 	/**
@@ -65,6 +71,9 @@ public abstract class Literals {
 	 */
 	public static class AnonymousLiteral{
 		public static final Literal ANONYMOUS = LiteralFactory.createAnonymousLiteral("_:a");
+
+		private AnonymousLiteral() {
+		}
 	}
 
 	/**

--- a/internetofevents/src/main/java/lupos/event/util/Prefixes.java
+++ b/internetofevents/src/main/java/lupos/event/util/Prefixes.java
@@ -27,4 +27,7 @@ public class Prefixes {
 	public static final String RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
 	/** Constant <code>XSD="http://www.w3.org/2001/XMLSchema#"</code> */
 	public static final String XSD = "http://www.w3.org/2001/XMLSchema#";
+
+	private Prefixes() {
+	}
 }

--- a/internetofevents/src/main/java/lupos/event/util/Utils.java
+++ b/internetofevents/src/main/java/lupos/event/util/Utils.java
@@ -44,6 +44,9 @@ import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.impl.client.DefaultHttpClient;
 public final class Utils {
 
+	private Utils() {
+	}
+
 	/**
 	 * Checks, if obj is a list and only contains elements of the same type
 	 *

--- a/operatorgraph/src/main/java/lupos/gui/operatorgraph/arrange/EdgeBased.java
+++ b/operatorgraph/src/main/java/lupos/gui/operatorgraph/arrange/EdgeBased.java
@@ -46,7 +46,10 @@ public class EdgeBased {
 	
 	private static HashMap<Integer, Double> directions = new HashMap<Integer, Double>();
 	private static HashMap<GraphWrapper, Integer> idHierarchy = new HashMap <GraphWrapper, Integer>();
-	
+
+	private EdgeBased() {
+	}
+
 	/**
 	 * Method gets the amount of different edge-types in 
 	 * the graph.

--- a/operatorgraph/src/main/java/lupos/gui/operatorgraph/arrange/GraphHelper.java
+++ b/operatorgraph/src/main/java/lupos/gui/operatorgraph/arrange/GraphHelper.java
@@ -31,6 +31,9 @@ import lupos.gui.operatorgraph.graphwrapper.GraphWrapper;
 import lupos.misc.Tuple;
 public class GraphHelper {
 
+	private GraphHelper() {
+	}
+
 	/**
 	 * If graph is out of display after a computed layout, this method fits it
 	 * back into the display

--- a/operatorgraph/src/main/java/lupos/gui/operatorgraph/arrange/LayeredDrawing.java
+++ b/operatorgraph/src/main/java/lupos/gui/operatorgraph/arrange/LayeredDrawing.java
@@ -39,6 +39,9 @@ import lupos.gui.operatorgraph.OperatorGraph;
 import lupos.gui.operatorgraph.graphwrapper.GraphWrapper;
 public final class LayeredDrawing {
 
+	private LayeredDrawing() {
+	}
+
 	/**
 	 * <p>updateX.</p>
 	 *

--- a/operatorgraph/src/main/java/lupos/gui/operatorgraph/arrange/LayoutTest.java
+++ b/operatorgraph/src/main/java/lupos/gui/operatorgraph/arrange/LayoutTest.java
@@ -31,7 +31,10 @@ import lupos.gui.operatorgraph.GraphWrapperIDTuple;
 import lupos.gui.operatorgraph.OperatorGraph;
 import lupos.gui.operatorgraph.graphwrapper.GraphWrapper;
 public class LayoutTest {
-	
+
+	private LayoutTest() {
+	}
+
 	/**
 	 * Method gets the number of edges in the graph
 	 * @param graph

--- a/operatorgraph/src/main/java/lupos/gui/operatorgraph/arrange/RndmLayout.java
+++ b/operatorgraph/src/main/java/lupos/gui/operatorgraph/arrange/RndmLayout.java
@@ -40,6 +40,9 @@ import lupos.misc.Tuple;
  */
 public class RndmLayout {
 
+	private RndmLayout() {
+	}
+
 	/**
 	 * <p>arrange.</p>
 	 *

--- a/operatorgraph/src/main/java/lupos/gui/operatorgraph/arrange/SpringEmbedder.java
+++ b/operatorgraph/src/main/java/lupos/gui/operatorgraph/arrange/SpringEmbedder.java
@@ -49,6 +49,9 @@ public class SpringEmbedder {
 	
 	private static long TIMEINTERVAL = 2500; // maximum time interval after which layouting is aborted 
 
+	private SpringEmbedder() {
+	}
+
 	/**
 	 * Method computes the repulsing force between two
 	 * nodes a and b. The result will be stored in force.

--- a/operatorgraph/src/main/java/lupos/gui/operatorgraph/arrange/Sugiyama.java
+++ b/operatorgraph/src/main/java/lupos/gui/operatorgraph/arrange/Sugiyama.java
@@ -41,7 +41,10 @@ import lupos.gui.operatorgraph.graphwrapper.GraphWrapper;
  * @version $Id: $Id
  */
 public final class Sugiyama {
-	
+
+	private Sugiyama() {
+	}
+
 	/**
 	 * Method gets a HashMap with the levels of the layout as keys
 	 * and lists of GraphWrapper which belong to the level

--- a/operatorgraph/src/main/java/lupos/misc/Helper.java
+++ b/operatorgraph/src/main/java/lupos/misc/Helper.java
@@ -23,6 +23,9 @@
  */
 package lupos.misc;
 public class Helper {
+	private Helper() {
+	}
+
 	/**
 	 * This method just is a workaround such that maven can compile and do not proclaim when an enum is directly casted!
 	 *

--- a/owl2rl/src/main/java/lupos/owl2rl/emitter/RuleEmitter.java
+++ b/owl2rl/src/main/java/lupos/owl2rl/emitter/RuleEmitter.java
@@ -31,6 +31,9 @@ import lupos.owl2rl.owlToRif.InferenceRulesGenerator;
 import lupos.owl2rl.owlToRif.TemplateRule;
 public class RuleEmitter {
 
+	private RuleEmitter() {
+	}
+
 	/**
 	 * <p>emitPropertyRules.</p>
 	 *

--- a/owl2rl/src/main/java/lupos/owl2rl/tools/Tools.java
+++ b/owl2rl/src/main/java/lupos/owl2rl/tools/Tools.java
@@ -23,6 +23,9 @@
  */
 package lupos.owl2rl.tools;
 public class Tools {
+	private Tools() {
+	}
+
 	/**
 	 * <p>forall.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/BooleanFunctions.java
+++ b/rif/src/main/java/lupos/rif/builtin/BooleanFunctions.java
@@ -28,6 +28,9 @@ import lupos.datastructures.items.literal.TypedLiteral;
 @Namespace(value = "http://www.w3.org/2007/rif-builtin-function#")
 public class BooleanFunctions {
 
+	private BooleanFunctions() {
+	}
+
 	/**
 	 * <p>not.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/BooleanPredicates.java
+++ b/rif/src/main/java/lupos/rif/builtin/BooleanPredicates.java
@@ -29,6 +29,9 @@ import lupos.datastructures.items.literal.TypedLiteral;
 @Namespace(value = "http://www.w3.org/2007/rif-builtin-predicate#")
 public class BooleanPredicates {
 
+	private BooleanPredicates() {
+	}
+
 	/**
 	 * <p>is_boolean.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/BuiltinHelper.java
+++ b/rif/src/main/java/lupos/rif/builtin/BuiltinHelper.java
@@ -47,6 +47,9 @@ import lupos.rif.datatypes.ListLiteral;
 import lupos.rif.model.RuleList;
 public class BuiltinHelper {
 
+	private BuiltinHelper() {
+	}
+
 	/**
 	 * <p>getSizeOfList.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/IteratorPredicates.java
+++ b/rif/src/main/java/lupos/rif/builtin/IteratorPredicates.java
@@ -30,6 +30,9 @@ import lupos.datastructures.items.literal.TypedLiteral;
 import lupos.misc.util.ImmutableIterator;
 public class IteratorPredicates {
 
+	private IteratorPredicates() {
+	}
+
 	/**
 	 * <p>numeric_less_than.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/ListFunctions.java
+++ b/rif/src/main/java/lupos/rif/builtin/ListFunctions.java
@@ -41,6 +41,9 @@ import com.google.common.collect.Lists;
 @Namespace(value = "http://www.w3.org/2007/rif-builtin-function#")
 public class ListFunctions {
 
+	private ListFunctions() {
+	}
+
 	/**
 	 * <p>make_list.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/ListPredicates.java
+++ b/rif/src/main/java/lupos/rif/builtin/ListPredicates.java
@@ -34,6 +34,9 @@ import lupos.rif.model.RuleList;
 @Namespace(value = "http://www.w3.org/2007/rif-builtin-predicate#")
 public class ListPredicates {
 
+	private ListPredicates() {
+	}
+
 	/**
 	 * <p>is_list.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/LiteralFunctions.java
+++ b/rif/src/main/java/lupos/rif/builtin/LiteralFunctions.java
@@ -31,6 +31,9 @@ import lupos.datastructures.items.literal.TypedLiteral;
 @Namespace(value = "http://www.w3.org/2007/rif-builtin-function#")
 public class LiteralFunctions {
 
+	private LiteralFunctions() {
+	}
+
 	/**
 	 * <p>fromStringLang.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/LiteralPredicates.java
+++ b/rif/src/main/java/lupos/rif/builtin/LiteralPredicates.java
@@ -27,6 +27,9 @@ import lupos.datastructures.items.literal.Literal;
 
 @Namespace(value = "http://www.w3.org/2007/rif-builtin-predicate#")
 public class LiteralPredicates {
+	private LiteralPredicates() {
+	}
+
 	/**
 	 * <p>literal_equal.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/NonStandardFunctions.java
+++ b/rif/src/main/java/lupos/rif/builtin/NonStandardFunctions.java
@@ -32,6 +32,9 @@ import lupos.datastructures.items.literal.TypedLiteral;
 @Namespace(value = "http://www.w3.org/2007/rif-builtin-function#")
 public class NonStandardFunctions {
 
+	private NonStandardFunctions() {
+	}
+
 	/**
 	 * <p>blankNodeFromString.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/NonStandardPredicates.java
+++ b/rif/src/main/java/lupos/rif/builtin/NonStandardPredicates.java
@@ -31,6 +31,9 @@ import lupos.datastructures.items.literal.URILiteral;
 
 @Namespace(value = "http://www.w3.org/2007/rif-builtin-predicate#")
 public class NonStandardPredicates {
+	private NonStandardPredicates() {
+	}
+
 	/**
 	 * <p>is_literal.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/NumericFunctions.java
+++ b/rif/src/main/java/lupos/rif/builtin/NumericFunctions.java
@@ -30,6 +30,9 @@ import lupos.datastructures.items.literal.TypedLiteral;
 @Namespace(value = "http://www.w3.org/2007/rif-builtin-function#")
 public class NumericFunctions {
 
+	private NumericFunctions() {
+	}
+
 	/**
 	 * <p>numeric_add.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/NumericPredicates.java
+++ b/rif/src/main/java/lupos/rif/builtin/NumericPredicates.java
@@ -30,6 +30,9 @@ import lupos.datastructures.items.literal.TypedLiteral;
 @Namespace(value = "http://www.w3.org/2007/rif-builtin-predicate#")
 public class NumericPredicates {
 
+	private NumericPredicates() {
+	}
+
 	/**
 	 * <p>numeric_equal.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/RDFDatatypesBuilder.java
+++ b/rif/src/main/java/lupos/rif/builtin/RDFDatatypesBuilder.java
@@ -29,6 +29,9 @@ import lupos.datastructures.items.literal.TypedLiteral;
 @Namespace(value = "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
 public class RDFDatatypesBuilder {
 
+	private RDFDatatypesBuilder() {
+	}
+
 	/**
 	 * <p>buildXmlLiteral.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/RIFBuiltinFactory.java
+++ b/rif/src/main/java/lupos/rif/builtin/RIFBuiltinFactory.java
@@ -51,6 +51,9 @@ public class RIFBuiltinFactory {
 					NonStandardFunctions.class);
 	private static final Map<String, Tuple<Builtin, Method>> builtins = new HashMap<String, Tuple<Builtin, Method>>();
 
+	private RIFBuiltinFactory() {
+	}
+
 	/**
 	 * <p>canBind.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/SchemaDatatypeBuilders.java
+++ b/rif/src/main/java/lupos/rif/builtin/SchemaDatatypeBuilders.java
@@ -31,6 +31,9 @@ import lupos.datastructures.items.literal.TypedLiteral;
 @Namespace(value = "http://www.w3.org/2001/XMLSchema#")
 public class SchemaDatatypeBuilders {
 
+	private SchemaDatatypeBuilders() {
+	}
+
 	/**
 	 * <p>buildBoolean.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/StringFunctions.java
+++ b/rif/src/main/java/lupos/rif/builtin/StringFunctions.java
@@ -29,6 +29,9 @@ import lupos.datastructures.items.literal.TypedLiteral;
 @Namespace(value = "http://www.w3.org/2007/rif-builtin-function#")
 public class StringFunctions {
 
+	private StringFunctions() {
+	}
+
 	/**
 	 * <p>compare.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/StringPredicates.java
+++ b/rif/src/main/java/lupos/rif/builtin/StringPredicates.java
@@ -36,6 +36,9 @@ import lupos.datastructures.items.literal.string.StringLiteral;
 @Namespace(value = "http://www.w3.org/2007/rif-builtin-predicate#")
 public class StringPredicates {
 
+	private StringPredicates() {
+	}
+
 	/**
 	 * <p>is_string.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/TimeFunctions.java
+++ b/rif/src/main/java/lupos/rif/builtin/TimeFunctions.java
@@ -46,6 +46,9 @@ import lupos.datastructures.items.literal.TypedLiteral;
 @Namespace(value = "http://www.w3.org/2007/rif-builtin-function#")
 public class TimeFunctions {
 
+	private TimeFunctions() {
+	}
+
 	/**
 	 * <p>year_from_dateTime.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/builtin/TimePredicates.java
+++ b/rif/src/main/java/lupos/rif/builtin/TimePredicates.java
@@ -28,6 +28,9 @@ import lupos.datastructures.items.literal.Literal;
 @Namespace(value = "http://www.w3.org/2007/rif-builtin-predicate#")
 public class TimePredicates {
 
+	private TimePredicates() {
+	}
+
 	/**
 	 * <p>is_date.</p>
 	 *

--- a/rif/src/main/java/lupos/rif/generated/parser/RIFParser.java
+++ b/rif/src/main/java/lupos/rif/generated/parser/RIFParser.java
@@ -2122,6 +2122,9 @@ public class RIFParser implements RIFParserConstants {
 
 class JTBToolkit {
 
+  private JTBToolkit() {
+  }
+
   static NodeToken makeNodeToken(final Token t) {
     return new NodeToken(t.image.intern(), t.kind, t.beginLine, t.beginColumn, t.endLine, t.endColumn);
   }

--- a/rifeditor/src/main/java/lupos/gui/ResultPanelHelper.java
+++ b/rifeditor/src/main/java/lupos/gui/ResultPanelHelper.java
@@ -60,6 +60,9 @@ import lupos.sparql1_1.ASTSelectQuery;
 import lupos.sparql1_1.ASTVar;
 import lupos.sparql1_1.Node;
 public final class ResultPanelHelper {
+	private ResultPanelHelper() {
+	}
+
 	/**
 	 * This is just for external use an easy way to display the result of a RIF rules application...
 	 *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.