### PR TITLE
equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/core/src/main/java/lupos/datastructures/dbmergesortedds/Entry.java
+++ b/core/src/main/java/lupos/datastructures/dbmergesortedds/Entry.java
@@ -75,6 +75,16 @@ public class Entry<E> implements Comparable<Entry<E>>, Serializable {
 		return comp.compare(e, ((Entry<E>) other).e) == 0;
 	}
 
+	@Override
+	public int hashCode() {
+		int result = this.e != null ? this.e.hashCode() : 0;
+		result = 31 * result + this.run;
+		result = 31 * result + this.n;
+		result = 31 * result + (this.comp != null ? this.comp.hashCode() : 0);
+		result = 31 * result + (this.runMatters ? 1 : 0);
+		return result;
+	}
+
 	public boolean runMatters = true;
 
 	/**

--- a/core/src/main/java/lupos/datastructures/items/literal/AnonymousLiteral.java
+++ b/core/src/main/java/lupos/datastructures/items/literal/AnonymousLiteral.java
@@ -86,6 +86,13 @@ public class AnonymousLiteral extends Literal implements Externalizable {
 		}
 	}
 
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (this.content != null ? this.content.hashCode() : 0);
+		return result;
+	}
+
 	/**
 	 * <p>Getter for the field <code>content</code>.</p>
 	 *

--- a/core/src/main/java/lupos/datastructures/items/literal/LanguageTaggedLiteral.java
+++ b/core/src/main/java/lupos/datastructures/items/literal/LanguageTaggedLiteral.java
@@ -85,6 +85,14 @@ public class LanguageTaggedLiteral extends Literal implements Externalizable {
 		}
 	}
 
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (this.content != null ? this.content.hashCode() : 0);
+		result = 31 * result + (this.lang != null ? this.lang.hashCode() : 0);
+		return result;
+	}
+
 	/** {@inheritDoc} */
 	@Override
 	public String toString() {

--- a/core/src/main/java/lupos/datastructures/items/literal/codemap/CodeMapURILiteral.java
+++ b/core/src/main/java/lupos/datastructures/items/literal/codemap/CodeMapURILiteral.java
@@ -176,6 +176,14 @@ public class CodeMapURILiteral extends URILiteral implements Externalizable {
 		}
 	}
 
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (this.content != null ? this.content.hashCode() : 0);
+		result = 31 * result + this.prefix;
+		return result;
+	}
+
 	/** {@inheritDoc} */
 	@Override
 	public String getString() {

--- a/core/src/main/java/lupos/datastructures/patriciatrie/node/Node.java
+++ b/core/src/main/java/lupos/datastructures/patriciatrie/node/Node.java
@@ -23,6 +23,8 @@
  */
 package lupos.datastructures.patriciatrie.node;
 
+import java.util.Arrays;
+
 /**
  * This class implements some of the base algorithms that can be executed on Patricia Tries.
  *
@@ -377,6 +379,15 @@ public abstract class Node {
 
 		// No differences found
 		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = Arrays.hashCode(this.content);
+		result = 31 * result + this.numberOfEntries;
+		result = 31 * result + (this.changed ? 1 : 0);
+		result = 31 * result + (this.onRecursionStack ? 1 : 0);
+		return result;
 	}
 
 	/**

--- a/core/src/main/java/lupos/datastructures/simplifiedfractaltree/FractalTreeEntry.java
+++ b/core/src/main/java/lupos/datastructures/simplifiedfractaltree/FractalTreeEntry.java
@@ -123,6 +123,15 @@ public class FractalTreeEntry<K extends Comparable<K>, V> implements Comparable<
 		return this.compareTo((FractalTreeEntry<K, V>) arg0) == 0;
 	}
 
+	@Override
+	public int hashCode() {
+		int result = this.key != null ? this.key.hashCode() : 0;
+		result = 31 * result + (this.value != null ? this.value.hashCode() : 0);
+		result = 31 * result + this.pointer;
+		result = 31 * result + (this.flag ? 1 : 0);
+		return result;
+	}
+
 	/** {@inheritDoc} */
 	@Override
 	public int compare(final FractalTreeEntry<K, V> o1, final FractalTreeEntry<K, V> o2) {

--- a/distributedp2p/src/main/java/lupos/distributed/p2p/commandline/MenuSelector.java
+++ b/distributedp2p/src/main/java/lupos/distributed/p2p/commandline/MenuSelector.java
@@ -457,6 +457,14 @@ public class MenuSelector<T> {
 		}
 
 		@Override
+		public int hashCode() {
+			int result = this.value != null ? this.value.hashCode() : 0;
+			result = 31 * result + (this.key != null ? this.key.hashCode() : 0);
+			result = 31 * result + (this.niceName != null ? this.niceName.hashCode() : 0);
+			return result;
+		}
+
+		@Override
 		public int compareTo(final MenuItem<T> o) {
 			if (o != null) {
 				if (this.key == null || ((MenuItem<?>)o).key == null) {

--- a/internetofevents/src/main/java/lupos/event/broker/distributed/model/BProducer.java
+++ b/internetofevents/src/main/java/lupos/event/broker/distributed/model/BProducer.java
@@ -86,4 +86,11 @@ public class BProducer implements Serializable{
 		}
 		return false;
 	}
+
+	@Override
+	public int hashCode() {
+		int result = this.producedEvent != null ? this.producedEvent.hashCode() : 0;
+		result = 31 * result + (this.tcpInfo != null ? this.tcpInfo.hashCode() : 0);
+		return result;
+	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - “equals(Object obj)" and "hashCode()" should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.